### PR TITLE
Add $base to default config

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,6 +11,7 @@ if(file_exists(dirname(__FILE__).'/../config.php')) {
   class Config {
     public static $cache = false;
     public static $admins = [];
+    public static $base = '';
   }
 }
 


### PR DESCRIPTION
Without this, an installation without config file will instantly die on a “Fatal error”, trying to access an “undeclared static property” in Parse::useragent().