### PR TITLE
Allow follow-of

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ If a property supports multiple values, it will always be returned as an array. 
 * `like-of`
 * `repost-of`
 * `bookmark-of`
+* `follow-of`
 * `syndication`
 * `photo` (of an entry, not of a card)
 * `video`
@@ -416,6 +417,7 @@ The following post types are returned, which are slightly expanded from what is 
 * `photo`
 * `article`
 * `note`
+* `follow`
 
 
 #### Other Properties

--- a/lib/XRay/Formats/Mf2.php
+++ b/lib/XRay/Formats/Mf2.php
@@ -429,7 +429,7 @@ class Mf2 extends Format {
 
     // These properties are always returned as arrays and always URLs
     // If the value is an h-* object with a URL, the URL is used and a "ref" is added as well
-    self::collectArrayURLValues(['photo','video','audio','syndication','in-reply-to','like-of','repost-of','bookmark-of','quotation-of'], $item, $data, $refs, $http);
+    self::collectArrayURLValues(['photo','video','audio','syndication','in-reply-to','like-of','repost-of','bookmark-of','quotation-of','follow-of'], $item, $data, $refs, $http);
 
     // Hack to make quotation-of a single value
     if(isset($data['quotation-of']))

--- a/lib/XRay/PostType.php
+++ b/lib/XRay/PostType.php
@@ -38,6 +38,9 @@ class PostType {
     if(isset($post['photo']))
       return 'photo';
 
+    if(isset($post['follow-of']))
+      return 'follow';
+
     $content = '';
     if(isset($post['content']))
       $content = $post['content']['text'];


### PR DESCRIPTION
Bridgy Fed has started sending webmentions when someone follows you. Add support for the 'follow-of' property. See https://indieweb.org/follow#Bridgy_Fed

Example source from fed.brid.gy : https://fed.brid.gy/render?source=https%3A%2F%2Fmastodon.social%2Fb8177a60-8f80-47a0-b943-a9df876cf5d5&target=https%3A%2F%2Frealize.be%2F 