### PR TITLE
Hack in h-geo support

### DIFF
--- a/lib/XRay/Formats/Mf2.php
+++ b/lib/XRay/Formats/Mf2.php
@@ -340,6 +340,11 @@ class Mf2 extends Format {
             $hcard[$p] = $v;
           }
         }
+        // If we have a geo property, it overrides p-latitude and p-longitude
+        if(array_key_exists($mf2, 'geo') && in_array('h-geo', $mf2['geo']['type']) {
+          $hcard['latitude'] = $mf2['geo']['latitude'][0];
+          $hcard['longitude'] = $mf2['geo']['longitude'][0];
+        }
         return $hcard;
       }
     }


### PR DESCRIPTION
This adds h-geo microformat support. It's clunky but it should work. I'm no PHP gal so I hope you have CI or something that would test it.

Test case: [this post by me](https://fireburn.ru/posts/1567956895) that should contain a checkin with h-geo embedded. Should be parsed with latitude and longitude, showing a map in applications like Monocle.