### PR TITLE
Allow iframe from YouTube and Vimeo

### DIFF
--- a/controllers/Parse.php
+++ b/controllers/Parse.php
@@ -71,6 +71,10 @@ class Parse {
       $opts['include-mf1'] = $request->get('include-mf1') == 'false' ? false : true;
     }
 
+    if($request->get('allow-iframe-video')) {
+      $opts['allowIframeVideo'] = $request->get('allow-iframe-video') == 'true';
+    }
+
     $url = $request->get('url');
     $html = $request->get('html') ?: $request->get('body');
 

--- a/lib/XRay/Formats/Format.php
+++ b/lib/XRay/Formats/Format.php
@@ -67,6 +67,16 @@ abstract class Format implements iFormat {
 
     $config = HTMLPurifier_Config::createDefault();
     $config->set('Cache.DefinitionImpl', null);
+
+    if (\p3k\XRay\allow_iframe_video()) {
+      $allowed[] = 'iframe';
+      $config->set('HTML.SafeIframe', true);
+      $config->set('URI.SafeIframeRegexp', '%^(https?:)?//(www\.youtube(?:-nocookie)?\.com/embed/|player\.vimeo\.com/video/)%');
+      $config->set('AutoFormat.RemoveEmpty', true);
+      // Removes iframe in case it has no src. This strips the non-allowed domains.
+      $config->set('AutoFormat.RemoveEmpty.Predicate', array('iframe' => array(0 => 'src')));
+    }
+
     $config->set('HTML.AllowedElements', $allowed);
 
     if($baseURL) {

--- a/lib/XRay/Parser.php
+++ b/lib/XRay/Parser.php
@@ -12,6 +12,8 @@ class Parser {
   }
 
   public function parse($http_response, $opts=[]) {
+    $allowIframeVideo = isset($opts['allowIframeVideo']) ? $opts['allowIframeVideo'] : false;
+    allow_iframe_video($allowIframeVideo);
     $document = $this->parse_document($http_response, $opts);
 
     // If a target parameter was provided, make sure a link to it exists in the parsed document

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -58,3 +58,12 @@ function phpmf2_version() {
   }
   return $version;
 }
+
+function allow_iframe_video($value = NULL) {
+  static $allow_iframe_video = false;
+
+  if (isset($value))
+    $allow_iframe_video = $value;
+
+  return $allow_iframe_video;
+}

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -127,7 +127,6 @@ class SanitizeTest extends PHPUnit_Framework_TestCase {
     $body = $response->getContent();
     $data = json_decode($body, true);
     $html = $data['data']['content']['html'];
-    file_put_contents('html', $html);
     $this->assertContains('youtube.com', $html);
     $this->assertNotContains('https://attack-domain.com', $html);
     $this->assertNotContains('<iframe width="580" height="345"', $html);

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -121,7 +121,7 @@ class SanitizeTest extends PHPUnit_Framework_TestCase {
     $body = $response->getContent();
     $data = json_decode($body, true);
     $html = $data['data']['content']['html'];
-    $this->assertNotContains('<iframe>', $html);
+    $this->assertNotContains('<iframe', $html);
 
     $response = $this->parse(['url' => $url, 'allow-iframe-video' => 'true']);
     $body = $response->getContent();

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -115,6 +115,24 @@ class SanitizeTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals('This content has some <i>HTML escaped</i> entities such as &amp; ampersand, " quote, escaped &lt;code&gt; HTML tags, an ümlaut, an @at sign.', $data['data']['content']['html']);
   }
 
+  public function testAllowIframeVideo()  {
+    $url = 'http://sanitize.example/entry-with-iframe-video';
+    $response = $this->parse(['url' => $url]);
+    $body = $response->getContent();
+    $data = json_decode($body, true);
+    $html = $data['data']['content']['html'];
+    $this->assertNotContains('<iframe>', $html);
+
+    $response = $this->parse(['url' => $url, 'allow-iframe-video' => 'true']);
+    $body = $response->getContent();
+    $data = json_decode($body, true);
+    $html = $data['data']['content']['html'];
+    file_put_contents('html', $html);
+    $this->assertContains('youtube.com', $html);
+    $this->assertNotContains('https://attack-domain.com', $html);
+    $this->assertNotContains('<iframe width="580" height="345"', $html);
+  }
+
   public function testSanitizeJavascriptURLs() {
     $url = 'http://sanitize.example/h-entry-with-javascript-urls';
     $response = $this->parse(['url' => $url]);

--- a/tests/data/sanitize.example/entry-with-iframe-video
+++ b/tests/data/sanitize.example/entry-with-iframe-video
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Server: Apache
+Date: Wed, 09 Dec 2015 03:29:14 GMT
+Content-Type: text/html; charset=utf-8
+Connection: keep-alive
+
+<html>
+  <head>
+    <title>Test</title>
+  </head>
+  <body class="h-entry">
+    <div class="e-content">
+      <p>This is a nice video!</p>
+      <iframe width="560" height="315" src="https://www.youtube.com/embed/y9FSPcmybT8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      <p>This is a not a nice video!</p>
+      <iframe width="580" height="345" src="https://attack-domain.com" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
It's tricky to pass on $opts in all parsers to get to Formats, so I used a helper function which keeps a static variable. See allow_iframe_video()