### PR TITLE
fix: check prefix correctly

### DIFF
--- a/lib/XRay/PostType.php
+++ b/lib/XRay/PostType.php
@@ -59,7 +59,7 @@ class PostType {
 
     // If this processed "name" property value is NOT a prefix of the
     // processed "content" property, then it is an article post.
-    if(strpos($content, $name) === false) {
+    if(strpos($content, $name) !== 0) {
       return 'article';
     }
 

--- a/tests/data/feed.example.com/rss
+++ b/tests/data/feed.example.com/rss
@@ -90,7 +90,7 @@ Connection: keep-alive
     <slash:comments>0</slash:comments>
     </item>
     <item>
-    <title>Bridgy Fed</title>
+    <title></title>
     <link>https://snarfed.org/2017-10-22_bridgy-fed</link>
     <comments>https://snarfed.org/2017-10-22_bridgy-fed#respond</comments>
     <pubDate>Mon, 23 Oct 2017 04:01:46 +0000</pubDate>


### PR DESCRIPTION
`strpos(string, sub)` returns `false` if `sub` is not present in `string`. In this case, we want to check if `sub` is not a *prefix* of `string`. Hence, we just need to test if the returned position is simply different from 0.

About the test I changed: The test is checking for notes, but 'Bridge Fed' is, in fact, an article according to the post discovery algorithm. Also, I'm adding as note that the main difference between a note and an article is that the latter has a title, while the first doesn't.