### PR TITLE
Fix preg_replace deprecations

### DIFF
--- a/lib/XRay/Formats/Mf2.php
+++ b/lib/XRay/Formats/Mf2.php
@@ -408,11 +408,11 @@ class Mf2 extends Format {
     $checkedname = $name;
     if($content) {
       // Trim ellipses from the name
-      $name = preg_replace('/ ?(\.\.\.|…)$/', '', $name);
+      $name = preg_replace('/ ?(\.\.\.|…)$/', '', $name ?: '');
 
       // Remove all whitespace when checking equality
-      $nameCompare = preg_replace('/\s/','',trim($name));
-      $contentCompare = preg_replace('/\s/','',trim($textContent));
+      $nameCompare = preg_replace('/\s/','',trim($name) ?: '');
+      $contentCompare = preg_replace('/\s/','',trim($textContent) ?: '');
 
       // Check if the name is a prefix of the content
       if($contentCompare && $nameCompare && strpos($contentCompare, $nameCompare) === 0) {

--- a/lib/XRay/PostType.php
+++ b/lib/XRay/PostType.php
@@ -54,8 +54,8 @@ class PostType {
     $name = trim($post['name']);
 
     // Collapse all sequences of internal whitespace to a single space (0x20) character each
-    $name = preg_replace('/\s+/', ' ', $name);
-    $content = preg_replace('/\s+/', ' ', $content);
+    $name = preg_replace('/\s+/', ' ', $name ?: '');
+    $content = preg_replace('/\s+/', ' ', $content ?: '');
 
     // If this processed "name" property value is NOT a prefix of the
     // processed "content" property, then it is an article post.


### PR DESCRIPTION
This fixes the following deprecation error:

php preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated