### PR TITLE
Used default options for fetching as well as parsing

### DIFF
--- a/lib/XRay.php
+++ b/lib/XRay.php
@@ -30,7 +30,12 @@ class XRay {
   public function parse($url, $opts_or_body=false, $opts_for_body=[]) {
     if(!$opts_or_body || is_array($opts_or_body)) {
       $fetch = new XRay\Fetcher($this->http);
-      $response = $fetch->fetch($url, $opts_or_body);
+      if (is_array($opts_or_body)) {
+        $fetch_opts = array_merge($this->defaultOptions, $opts_or_body);
+      } else {
+        $fetch_opts = $this->defaultOptions;
+      }
+      $response = $fetch->fetch($url, $fetch_opts);
       if(!empty($response['error']))
         return $response;
       $body = $response['body'];

--- a/tests/FetchTestDisabled.php
+++ b/tests/FetchTestDisabled.php
@@ -32,7 +32,6 @@ class FetchTest extends PHPUnit\Framework\TestCase
     {
         $url = 'https://nghttp2.org/httpbin/ip';
         $response = $this->http->get($url);
-        $this->assertEquals('', $response['error']);    
+        $this->assertEquals('', $response['error']);
     }
-
 }

--- a/tests/LibraryTest.php
+++ b/tests/LibraryTest.php
@@ -108,4 +108,30 @@ class LibraryTest extends PHPUnit\Framework\TestCase
             $normalXRay->parse($url, $html)
         );
     }
+
+    public function testDefaultOptionsAreUsedForFetching()
+    {
+        // LibraryTest::testDefaultOptionsAreUsed can only test that default options are merged and passed 
+        // to the relevant format handler. To test that they’re additionally passed to the fetcher currently
+        // requires a network request to the twitter API for an auth error.
+        // A potential future improvement for this would be to make a new mock HTTP client object which 
+        // accepts a callback, which gets passed the request it would send. We can then check that the
+        // request has the parameters we want without having to actually hit the network.
+        $url = 'https://twitter.com/BarnabyWalters/status/990659593561952256';
+
+        // Confirm the expected behaviour.
+        $xray = new p3k\XRay();
+        $result = $xray->parse($url);
+        $this->assertEquals('missing_parameters', $result['error']);
+
+        $xray = new p3k\XRay([
+            'twitter_api_key' => 'extremely real API credentials',
+            'twitter_api_secret' => 'extremely real API credentials',
+            'twitter_access_token' => 'extremely real API credentials',
+            'twitter_access_token_secret' => 'extremely real API credentials'
+        ]);
+        $result = $xray->parse($url);
+        $this->assertEquals('twitter_error', $result['error']);
+    }
+
 }

--- a/tests/LibraryTest.php
+++ b/tests/LibraryTest.php
@@ -108,5 +108,4 @@ class LibraryTest extends PHPUnit\Framework\TestCase
             $normalXRay->parse($url, $html)
         );
     }
-
 }


### PR DESCRIPTION
Fixes a bug introduced in #111 where default options would be applied during the parsing stage but not the fetching stage. Default options are now passed to both. Covered using a test which hits the twitter API as a temporary measure, with a suggestion for how this could be mocked in the future.