### PR TITLE
allow redirects on Bridgy, Bridgy Fed, and appspot.com

### DIFF
--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -41,7 +41,7 @@ function build_url($parsed_url) {
 
 function should_follow_redirects($url) {
   $host = parse_url($url, PHP_URL_HOST);
-  if(preg_match('/brid\.gy|appspot\.com|blogspot\.com|youtube\.com/', $host)) {
+  if(preg_match('/blogspot\.com|youtube\.com/', $host)) {
     return false;
   } else {
     return true;


### PR DESCRIPTION
fixes #118. as far as we can tell, this is probably the root cause of [a number of bugs filed against webmention.io over the last couple years](https://github.com/aaronpk/webmention.io/issues), eg aaronpk/webmention.io#188, aaronpk/webmention.io#187, aaronpk/webmention.io#175, aaronpk/webmention.io#173, etc.

@aaronpk [said](https://chat.indieweb.org/dev/2023-08-07#t1691382116891200):
> That was apparently added 8 years ago
> i vaguely remember some old issue with appspot URLs that I had to work around

that appspot URL issue was probably that it required SNI for SSL, which was less supported then, and much more widely supported now, so I'm pretty sure this change is ok.

cc @osak
